### PR TITLE
Build and deploy docker images from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     - git submodule update --init --recursive
 before_deploy:
   - docker build -t spark:latest spark-docker
-  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+  - docker login -u $DOCKER_USERNAME -p $(echo $DOCKER_PASSWORD | base64 -d)
 deploy:
   # deploy master to the staging environment
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+sudo: required
 language: java
+services: 
+  - docker
 jdk:
   - oraclejdk8
 #  - openjdk7
@@ -9,3 +12,19 @@ git:
 before_install:
     - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
     - git submodule update --init --recursive
+before_deploy:
+  - docker build -t spark:latest spark-docker
+  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+deploy:
+  # deploy master to the staging environment
+  - provider: script
+    skip_cleanup: true
+    script: ./deploy.sh staging
+    on:
+      branch: master
+  # deploy master to production
+  - provider: script
+    skip_cleanup: true
+    script: ./deploy.sh production
+    on:
+      branch: production

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+IMAGE_TAG=$DOCKER_USERNAME/spark-$1:latest
+docker tag spark:latest $IMAGE_TAG
+
+docker push $IMAGE_TAG
+
+# trigger autoredeploy for the affected environment


### PR DESCRIPTION
Update `.travis.yml` to build and push updated spark-docker images to dockerhub.

### Note
Add the following environment variables to travis
* DOCKER_USERNAME
* DOCKER_PASSWORD
 
DOCKER_PASSWORD should be base64 encoded 
```bash
echo -n 'YOUR_DOCKERPASSWORD' | base64 
```
See sample output here: https://travis-ci.org/0sc/people-match-ai/builds/321387095

After the build, image should be available at https://hub.docker.com/u/DOCKER_USERNAME/spark-staging build or https://hub.docker.com/u/DOCKER_USERNAME/park-production if production build